### PR TITLE
Use full path when generating typedefs for message type

### DIFF
--- a/src/translate.cpp
+++ b/src/translate.cpp
@@ -402,7 +402,7 @@ static std::string members_to_meta(
         auto sub_members = static_cast<const MessageMembers *>(member->members_->data);
         auto msg_path = get_type_from_message_members(sub_members);
 
-        s << sub_members->message_name_ << b << " " << name << "\n";
+        s << msg_path << b << " " << name << "\n";
 
         if (deps.count(msg_path) == 0) {
           deps[msg_path] = members_to_meta(sub_members, deps, rosbridge_compatible, name);

--- a/test/translate_test.cpp
+++ b/test/translate_test.cpp
@@ -39,8 +39,8 @@ TEST_F(TranslateFixture, DescribeStdMsgsBuiltins)
   auto msg_desc = generate_message_meta("test_msgs/msg/Builtins");
 
   std::string expected =
-    "Duration duration_value\n"
-    "Time time_value\n"
+    "builtin_interfaces/msg/Duration duration_value\n"
+    "builtin_interfaces/msg/Time time_value\n"
     "============\n"
     "MSG: builtin_interfaces/msg/Duration\n"
     "int32 sec\n"
@@ -58,7 +58,7 @@ TEST_F(TranslateFixture, RosbridgeCompatibleDescriptionHasRenamedNanosecondsFiel
   auto msg_desc = generate_message_meta("rcl_interfaces/msg/Log", true);
 
   std::string expected =
-    "Time stamp\n"
+    "builtin_interfaces/msg/Time stamp\n"
     "uint8 level\n"
     "string name\n"
     "string msg\n"
@@ -92,9 +92,9 @@ TEST_F(TranslateFixture, DescribeTestMsgsUnboundedSequence)
     "int64[] int64_values\n"
     "uint64[] uint64_values\n"
     "string[] string_values\n"
-    "BasicTypes[] basic_types_values\n"
-    "Constants[] constants_values\n"
-    "Defaults[] defaults_values\n"
+    "test_msgs/msg/BasicTypes[] basic_types_values\n"
+    "test_msgs/msg/Constants[] constants_values\n"
+    "test_msgs/msg/Defaults[] defaults_values\n"
     "bool[] bool_values_default\n"
     "uint8[] byte_values_default\n"
     "uint8[] char_values_default\n"
@@ -165,9 +165,9 @@ TEST_F(TranslateFixture, DescribeTestMsgsArrays)
     "int64[3] int64_values\n"
     "uint64[3] uint64_values\n"
     "string[3] string_values\n"
-    "BasicTypes[3] basic_types_values\n"
-    "Constants[3] constants_values\n"
-    "Defaults[3] defaults_values\n"
+    "test_msgs/msg/BasicTypes[3] basic_types_values\n"
+    "test_msgs/msg/Constants[3] constants_values\n"
+    "test_msgs/msg/Defaults[3] defaults_values\n"
     "bool[3] bool_values_default\n"
     "uint8[3] byte_values_default\n"
     "uint8[3] char_values_default\n"
@@ -244,6 +244,30 @@ TEST_F(TranslateFixture, DeserializeRclInterfacesLogMessage)
 
   auto log_msg_json = rws::serialized_message_to_json("rcl_interfaces/msg/Log", serialized_msg);
   EXPECT_EQ(log_msg_json, expected);
+}
+
+TEST_F(TranslateFixture, DescribeMsgsNestedType)
+{
+  auto msg_desc = generate_message_meta("sensor_msgs/Image");
+
+  std::string expected =
+    "std_msgs/msg/Header header\n"
+    "uint32 height\n"
+    "uint32 width\n"
+    "string encoding\n"
+    "uint8 is_bigendian\n"
+    "uint32 step\n"
+    "uint8[] data\n"
+    "============\n"
+    "MSG: builtin_interfaces/msg/Time\n"
+    "int32 sec\n"
+    "uint32 nanosec\n"
+    "============\n"
+    "MSG: std_msgs/msg/Header\n"
+    "builtin_interfaces/msg/Time stamp\n"
+    "string frame_id\n";
+
+  EXPECT_EQ(msg_desc, expected);
 }
 
 }  // namespace rws


### PR DESCRIPTION
Hi!
I have notice that running foxglove with the bridge show some errors when trying to parse /topics_and_raw_types for complex types. E.g. types that contains e.g. a header type. It cannot solve Header it needs the full path std_msgs/msg/Header.

See console errors from browser below

`
3524.0ed3d11ba3fb8482838c.js:79 Error: Expected 1 top level type definition for 'Header' but found 0
    at f (5820.27f2c9eaba8daa4be416.js:32:1250)
    at 5820.27f2c9eaba8daa4be416.js:32:487
    at Array.forEach (<anonymous>)
    at 5820.27f2c9eaba8daa4be416.js:32:408
    at Array.forEach (<anonymous>)
    at e (5820.27f2c9eaba8daa4be416.js:32:371)
    at t (5820.27f2c9eaba8daa4be416.js:32:338)
    at #T (3524.0ed3d11ba3fb8482838c.js:79:22247)
`
`
(anonymous) @ 3524.0ed3d11ba3fb8482838c.js:79
3524.0ed3d11ba3fb8482838c.js:79 Player problem requestTopics:error {severity: 'error', message: 'Failed to fetch topics from rosbridge', error: Error: Expected 1 top level type definition for 'Header' but found 0
    at f (https://app.foxglove…}
`

This fix solves the errors