### PR TITLE
Socket throttle_rate support

### DIFF
--- a/include/rws/client_handler.hpp
+++ b/include/rws/client_handler.hpp
@@ -66,7 +66,7 @@ private:
   bool advertise_topic(const json & request, json & response_out);
   bool unadvertise_topic(const json & request, json & response_out);
   bool publish_to_topic(const json & request, json & response_out);
-  void subscription_callback(topic_params params, std::shared_ptr<const rclcpp::SerializedMessage> message);
+  void subscription_callback(topic_params & params, std::shared_ptr<const rclcpp::SerializedMessage> message);
 
   // Service handlers
   bool call_service(const json & request, json & response_out);

--- a/include/rws/client_handler.hpp
+++ b/include/rws/client_handler.hpp
@@ -35,8 +35,6 @@ public:
     std::function<void(std::vector<std::uint8_t> & msg)> binary_callback);
   json process_message(json & msg);
 
-  void subscription_callback(topic_params & params, std::shared_ptr<const rclcpp::SerializedMessage> message);
-
   ~ClientHandler();
 
 private:
@@ -68,6 +66,7 @@ private:
   bool advertise_topic(const json & request, json & response_out);
   bool unadvertise_topic(const json & request, json & response_out);
   bool publish_to_topic(const json & request, json & response_out);
+  void subscription_callback(topic_params & params, std::shared_ptr<const rclcpp::SerializedMessage> message);
 
   // Service handlers
   bool call_service(const json & request, json & response_out);

--- a/include/rws/client_handler.hpp
+++ b/include/rws/client_handler.hpp
@@ -35,6 +35,8 @@ public:
     std::function<void(std::vector<std::uint8_t> & msg)> binary_callback);
   json process_message(json & msg);
 
+  void subscription_callback(topic_params & params, std::shared_ptr<const rclcpp::SerializedMessage> message);
+
   ~ClientHandler();
 
 private:
@@ -66,7 +68,6 @@ private:
   bool advertise_topic(const json & request, json & response_out);
   bool unadvertise_topic(const json & request, json & response_out);
   bool publish_to_topic(const json & request, json & response_out);
-  void subscription_callback(topic_params & params, std::shared_ptr<const rclcpp::SerializedMessage> message);
 
   // Service handlers
   bool call_service(const json & request, json & response_out);

--- a/include/rws/connector.hpp
+++ b/include/rws/connector.hpp
@@ -12,7 +12,7 @@ namespace rws
 
 struct topic_params
 {
-  topic_params() : history_depth(10), compression("none"), topic(""), type(""), latch(false) {}
+  topic_params() : history_depth(10), compression("none"), topic(""), type(""), latch(false), throttle_rate(0), last_sent_timestamp(0) {}
   topic_params(std::string t, std::string tp)
   : history_depth(10), compression("none"), topic(t), type(tp), latch(false), throttle_rate(0), last_sent_timestamp(0)
   {
@@ -34,13 +34,13 @@ struct topic_params
             compression == p.compression &&
             latch == p.latch;
   }
-  uint64_t last_sent_timestamp;
   size_t history_depth;
-  size_t throttle_rate;
   std::string compression;  // rws internal
   std::string topic;
   std::string type;
   bool latch;  // only for publishers, rws internal
+  size_t throttle_rate;
+  uint64_t last_sent_timestamp;
 };
 
 typedef std::function<void(topic_params & params, std::shared_ptr<const rclcpp::SerializedMessage> message)>

--- a/test/client_handler_test.cpp
+++ b/test/client_handler_test.cpp
@@ -127,36 +127,6 @@ TEST_F(ClientHandlerFixture, rosapi_topic_and_raw_types_is_thread_safe)
   EXPECT_NE(server_node, nullptr);
 }
 
-TEST_F(ClientHandlerFixture, subscription_callback_throttles_messages)
-{
-  auto server_node = std::make_shared<rclcpp::Node>("server_node");
-  auto node_interface = std::make_shared<rws::NodeInterfaceImpl>(server_node);
-  auto connector = std::make_shared<rws::Connector<>>(node_interface);
-
-  std::vector<std::string> messages;
-  std::function<void(std::string &)> callback = [&messages](std::string & message) {
-    messages.push_back(message);
-  };
-  std::function<void(std::vector<std::uint8_t> &)> binary_callback = [](std::vector<std::uint8_t> &) {};
-
-  ClientHandler handler(0, node_interface, connector, true, callback, binary_callback);
-
-  topic_params params;
-  params.topic = "/test_topic";
-  params.type = "std_msgs/msg/String";
-  params.throttle_rate = 100;
-
-  auto message = std::make_shared<const rclcpp::SerializedMessage>();
-
-  // Send multiple messages rapidly
-  handler.subscription_callback(params, message);
-  handler.subscription_callback(params, message);
-  handler.subscription_callback(params, message);
-
-  // Check that the message was only actually sent once
-  EXPECT_EQ(messages.size(), 1);
-}
-
 }  // namespace rws
 
 int main(int argc, char ** argv)

--- a/test/connector_test.cpp
+++ b/test/connector_test.cpp
@@ -1,5 +1,4 @@
 #include "rws/connector.hpp"
-
 #include <gtest/gtest.h>
 
 #include "node_mock.hpp"
@@ -40,6 +39,7 @@ TEST_F(ConnectorFixture, subscribe_to_topic_calls_create_generic_subscription_wi
   EXPECT_EQ(params.topic, "/topic");
   EXPECT_EQ(params.type, "std_msgs/msg/String");
   EXPECT_EQ(params.history_depth, 10);
+  EXPECT_EQ(params.throttle_rate, 0);
   EXPECT_EQ(params.compression, "none");
 
   EXPECT_CALL(
@@ -60,6 +60,7 @@ TEST_F(ConnectorFixture, subscribe_to_topic_calls_create_generic_subscription_on
   EXPECT_EQ(params.topic, "/topic");
   EXPECT_EQ(params.type, "std_msgs/msg/String");
   EXPECT_EQ(params.history_depth, 10);
+  EXPECT_EQ(params.throttle_rate, 0);
   EXPECT_EQ(params.compression, "none");
 
   EXPECT_CALL(*node, create_generic_subscription(_, _, _, _, _)).Times(1).WillOnce(Return(nullptr));

--- a/test/connector_test.cpp
+++ b/test/connector_test.cpp
@@ -20,8 +20,9 @@ public:
 
   void SetUp() override
   {
-    messages.push_back(std::make_shared<const rclcpp::SerializedMessage>());
-    messages.push_back(std::make_shared<const rclcpp::SerializedMessage>());
+    for(int i = 0; i < 6; i++) {
+      messages.push_back(std::make_shared<const rclcpp::SerializedMessage>());
+    }
   }
 
   void TearDown() override { messages.clear(); }
@@ -346,14 +347,14 @@ TEST_F(ConnectorFixture, subscription_callback_throttles_messages)
   
   // "Publish" messages
   topic_callback(messages[0]); // last_sent = 0, 0
-  topic_callback(messages[0]); //             1000, 50
-  topic_callback(messages[0]); //             1000, 100
-  topic_callback(messages[1]); //             1000, 150
+  topic_callback(messages[1]); //             1000, 50
+  topic_callback(messages[2]); //             1000, 100
+  topic_callback(messages[3]); //             1000, 150
 
   // Expect client to receive first and last message
   EXPECT_EQ(client_msgs.size(), 2);
   EXPECT_EQ(client_msgs[0], messages[0]);
-  EXPECT_EQ(client_msgs[1], messages[1]);
+  EXPECT_EQ(client_msgs[1], messages[3]);
 }
 
 }  // namespace rws

--- a/test/connector_test.cpp
+++ b/test/connector_test.cpp
@@ -39,7 +39,7 @@ TEST_F(ConnectorFixture, subscribe_to_topic_calls_create_generic_subscription_wi
   EXPECT_EQ(params.topic, "/topic");
   EXPECT_EQ(params.type, "std_msgs/msg/String");
   EXPECT_EQ(params.history_depth, 10);
-  EXPECT_EQ(params.throttle_rate, 0);
+  EXPECT_EQ(params.throttle_rate.nanoseconds(), 0);
   EXPECT_EQ(params.compression, "none");
 
   EXPECT_CALL(
@@ -60,7 +60,7 @@ TEST_F(ConnectorFixture, subscribe_to_topic_calls_create_generic_subscription_on
   EXPECT_EQ(params.topic, "/topic");
   EXPECT_EQ(params.type, "std_msgs/msg/String");
   EXPECT_EQ(params.history_depth, 10);
-  EXPECT_EQ(params.throttle_rate, 0);
+  EXPECT_EQ(params.throttle_rate.nanoseconds(), 0);
   EXPECT_EQ(params.compression, "none");
 
   EXPECT_CALL(*node, create_generic_subscription(_, _, _, _, _)).Times(1).WillOnce(Return(nullptr));
@@ -308,6 +308,52 @@ TEST_F(ConnectorFixture, connector_unadvertise_when_no_more_clients_are_advertis
   // Unadvertise client 1 from topic 1
   client1_unadv_t1();
   EXPECT_EQ(connector.is_advertising_topic(topic1_p), false);
+}
+
+TEST_F(ConnectorFixture, subscription_callback_throttles_messages)
+{
+  auto node = std::make_shared<testing::NiceMock<NodeMock>>();
+  Connector<GenericPublisherMock> connector(node);
+
+  topic_params params;
+  params.topic = "/test_topic";
+  params.type = "std_msgs/msg/String";
+  params.throttle_rate = rclcpp::Duration(0, 100 * 1000000);
+
+  std::function<void(ConstSharedMessage)> topic_callback;
+  EXPECT_CALL(
+    *node, create_generic_subscription("/test_topic", "std_msgs/msg/String", rclcpp::QoS(10), _, _))
+    .Times(1)
+    .WillRepeatedly(
+      Invoke([&topic_callback](
+               const std::string &, const std::string &,
+               const rclcpp::QoS &, std::function<void(ConstSharedMessage)> callback,
+               const rclcpp::SubscriptionOptions &) {
+        topic_callback = callback;
+        return nullptr;
+      }));
+
+  rclcpp::Time now(1000, 0, RCL_ROS_TIME);
+  ON_CALL(*node, now()).WillByDefault(Invoke([&now](){
+    now += rclcpp::Duration(0, 50 * 1000000);
+    return now;
+  }));
+
+  // Received messages
+  std::vector<ConstSharedMessage> client_msgs;
+  connector.subscribe_to_topic(
+    0, params, [&client_msgs](topic_params, ConstSharedMessage message) { client_msgs.push_back(message); });
+  
+  // "Publish" messages
+  topic_callback(messages[0]); // last_sent = 0, 0
+  topic_callback(messages[0]); //             1000, 50
+  topic_callback(messages[0]); //             1000, 100
+  topic_callback(messages[1]); //             1000, 150
+
+  // Expect client to receive first and last message
+  EXPECT_EQ(client_msgs.size(), 2);
+  EXPECT_EQ(client_msgs[0], messages[0]);
+  EXPECT_EQ(client_msgs[1], messages[1]);
 }
 
 }  // namespace rws


### PR DESCRIPTION
So I've noticed that rws doesn't support the throttle_rate param from roslibjs, which can be kind of key when trying to send over large high rate topics like pointclouds and laserscans without clogging websockets over slow wifi, plus it should result in some minor CPU usage reduction in some cases. I think this is the last feature that's missing in rws compared to rosbridge.

I'm not all that well versed in cpp, but I've done this exploratory implementation to see what it would take to get it set up. It does seem to work from what I've tested it, but it likely needs some adjustments (or should be implemented some other way entirely), test coverage and a check to see what happpens in foxglove protocol mode.