### PR TITLE
QoS Matching

### DIFF
--- a/include/rws/connector.hpp
+++ b/include/rws/connector.hpp
@@ -60,14 +60,18 @@ public:
     auto matching_subscriber = get_subscriber_by_params(params);
     subscriber_handle handle = {nullptr, params, handler, client_id, next_handler_id_++, rclcpp::Time(0, 0, RCL_ROS_TIME)};
 
-    auto info = node_->get_publishers_info_by_topic(params.topic);
     rclcpp::QoS qos(params.history_depth);
+    auto info = node_->get_publishers_info_by_topic(params.topic);
     if (!info.empty()) {
       auto rmw_qos = info[0].qos_profile().get_rmw_qos_profile();
       qos.reliability(rmw_qos.reliability);
       qos.durability(rmw_qos.durability);
       qos.history(rmw_qos.history);
       qos.liveliness(rmw_qos.liveliness);
+    } else {
+      // no publishers yet, use an all-compatible QoS
+      qos.reliability(RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT);
+      qos.durability(RMW_QOS_POLICY_DURABILITY_VOLATILE);
     }
 
     bool is_transient_local = qos.durability() == rclcpp::DurabilityPolicy::TransientLocal;

--- a/include/rws/connector.hpp
+++ b/include/rws/connector.hpp
@@ -61,17 +61,31 @@ public:
     subscriber_handle handle = {nullptr, params, handler, client_id, next_handler_id_++, rclcpp::Time(0, 0, RCL_ROS_TIME)};
 
     rclcpp::QoS qos(params.history_depth);
-    auto info = node_->get_publishers_info_by_topic(params.topic);
-    if (!info.empty()) {
-      auto rmw_qos = info[0].qos_profile().get_rmw_qos_profile();
-      qos.reliability(rmw_qos.reliability);
-      qos.durability(rmw_qos.durability);
-      qos.history(rmw_qos.history);
-      qos.liveliness(rmw_qos.liveliness);
-    } else {
-      // no publishers yet, use an all-compatible QoS
+    auto publishers_info = node_->get_publishers_info_by_topic(params.topic);
+
+    if (publishers_info.empty()) {
+      // No publishers yet: use the same broadly compatible fallback as rosbridge.
       qos.reliability(RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT);
       qos.durability(RMW_QOS_POLICY_DURABILITY_VOLATILE);
+    } else {
+      bool all_reliable = true;
+      bool all_transient_local = true;
+
+      for (const auto & publisher_info : publishers_info) {
+        const auto rmw_qos =
+          publisher_info.qos_profile().get_rmw_qos_profile();
+
+        if (rmw_qos.reliability != RMW_QOS_POLICY_RELIABILITY_RELIABLE) {
+          all_reliable = false;
+        }
+
+        if (rmw_qos.durability != RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL) {
+          all_transient_local = false;
+        }
+      }
+
+      qos.reliability(all_reliable ? RMW_QOS_POLICY_RELIABILITY_RELIABLE : RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT);
+      qos.durability(all_transient_local ? RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL : RMW_QOS_POLICY_DURABILITY_VOLATILE);
     }
 
     bool is_transient_local = qos.durability() == rclcpp::DurabilityPolicy::TransientLocal;

--- a/include/rws/connector.hpp
+++ b/include/rws/connector.hpp
@@ -59,12 +59,17 @@ public:
 
     auto matching_subscriber = get_subscriber_by_params(params);
     subscriber_handle handle = {nullptr, params, handler, client_id, next_handler_id_++, rclcpp::Time(0, 0, RCL_ROS_TIME)};
-    rclcpp::QoS qos(params.history_depth);
+
     auto info = node_->get_publishers_info_by_topic(params.topic);
-    for(const auto& node : info)
-    {
-      qos.durability(node.qos_profile().get_rmw_qos_profile().durability);
+    rclcpp::QoS qos(params.history_depth);
+    if (!info.empty()) {
+      auto rmw_qos = info[0].qos_profile().get_rmw_qos_profile();
+      qos.reliability(rmw_qos.reliability);
+      qos.durability(rmw_qos.durability);
+      qos.history(rmw_qos.history);
+      qos.liveliness(rmw_qos.liveliness);
     }
+
     bool is_transient_local = qos.durability() == rclcpp::DurabilityPolicy::TransientLocal;
 
     if (matching_subscriber == nullptr || is_transient_local) {

--- a/src/client_handler.cpp
+++ b/src/client_handler.cpp
@@ -182,19 +182,33 @@ bool ClientHandler::subscribe_to_topic(const json & msg, json & response)
   }
 
   std::string topic = msg["topic"];
+  auto topics = node_->get_topic_names_and_types();
+  const auto topic_it = topics.find(topic);
   std::string sub_type;
   if (msg.contains("type") && msg["type"].is_string()) {
-    sub_type = msg["type"];
+    sub_type = rws::message_type_to_ros2_style(msg["type"]);
+
+    if (topic_it != topics.end()) {
+      const auto & discovered_types = topic_it->second;
+
+      if (std::find(discovered_types.begin(), discovered_types.end(), sub_type) == discovered_types.end())
+      {
+        response["error"] = "Topic " + topic + " exists, but not with requested type " + sub_type;
+        response["result"] = false;
+        RCLCPP_ERROR(get_logger(), "Failed to subscribe to topic: %s", response["error"].dump().c_str());
+        return true;
+      }
+    }
   } else {
-    std::map<std::string, std::vector<std::string>> topics = node_->get_topic_names_and_types();
-    if (topics.find(topic) == topics.end()) {
+    if (topic_it == topics.end()) {
       response["error"] = "Topic " + topic + " not found and no type specified";
       response["result"] = false;
       RCLCPP_ERROR(get_logger(), "Failed to subscribe to topic: %s", response["error"].dump().c_str());
       return true;
     }
-    sub_type = topics[topic][0];
+    sub_type = topic_it->second[0];
   }
+
   size_t history_depth = 10;
   if (msg.contains("history_depth") && msg["history_depth"].is_number()) {
     history_depth = msg["history_depth"];

--- a/src/client_handler.cpp
+++ b/src/client_handler.cpp
@@ -182,13 +182,18 @@ bool ClientHandler::subscribe_to_topic(const json & msg, json & response)
   }
 
   std::string topic = msg["topic"];
-  std::map<std::string, std::vector<std::string>> topics = node_->get_topic_names_and_types();
-  if (topics.find(topic) == topics.end()) {
-    response["error"] = "Topic " + topic + " not found";
-    response["result"] = false;
-    RCLCPP_ERROR(
-      get_logger(), "Failed to subscribe to topic: %s", response["error"].dump().c_str());
-    return true;
+  std::string sub_type;
+  if (msg.contains("type") && msg["type"].is_string()) {
+    sub_type = msg["type"];
+  } else {
+    std::map<std::string, std::vector<std::string>> topics = node_->get_topic_names_and_types();
+    if (topics.find(topic) == topics.end()) {
+      response["error"] = "Topic " + topic + " not found and no type specified";
+      response["result"] = false;
+      RCLCPP_ERROR(get_logger(), "Failed to subscribe to topic: %s", response["error"].dump().c_str());
+      return true;
+    }
+    sub_type = topics[topic][0];
   }
   size_t history_depth = 10;
   if (msg.contains("history_depth") && msg["history_depth"].is_number()) {
@@ -204,7 +209,6 @@ bool ClientHandler::subscribe_to_topic(const json & msg, json & response)
   std::string compression =
     (!msg.contains("compression") || !msg["compression"].is_string()) ? "none" : msg["compression"];
 
-  auto sub_type = topics[topic][0];
   if (subscriptions_.count(topic) == 0) {
     
     topic_params params(topic, sub_type, history_depth, compression, throttle_rate);

--- a/test/client_handler_test.cpp
+++ b/test/client_handler_test.cpp
@@ -127,6 +127,126 @@ TEST_F(ClientHandlerFixture, rosapi_topic_and_raw_types_is_thread_safe)
   EXPECT_NE(server_node, nullptr);
 }
 
+TEST_F(
+  ClientHandlerFixture,
+  subscribe_to_nonexistent_topic_succeeds_when_type_is_given)
+{
+  auto server_node = std::make_shared<rclcpp::Node>("server_node");
+  auto node_interface = std::make_shared<NodeInterfaceImpl>(server_node);
+  auto connector = std::make_shared<Connector<>>(node_interface);
+
+  ClientHandler handler(
+    0,
+    node_interface,
+    connector,
+    true,
+    [](std::string &) {},
+    [](std::vector<uint8_t> &) {});
+
+  auto json_o = json::parse(R"(
+    {
+      "id": "sub1",
+      "op": "subscribe",
+      "topic": "/topic_that_does_not_exist_yet",
+      "type": "std_msgs/msg/String"
+    }
+  )");
+
+  auto response = handler.process_message(json_o);
+
+  EXPECT_EQ(response["op"], "subscribe_response");
+  EXPECT_EQ(response["result"], true);
+  EXPECT_EQ(response["type"], "std_msgs/msg/String");
+}
+
+TEST_F(
+  ClientHandlerFixture,
+  subscribe_to_nonexistent_topic_fails_when_type_is_not_given)
+{
+  auto server_node = std::make_shared<rclcpp::Node>("server_node");
+  auto node_interface = std::make_shared<NodeInterfaceImpl>(server_node);
+  auto connector = std::make_shared<Connector<>>(node_interface);
+
+  ClientHandler handler(
+    0,
+    node_interface,
+    connector,
+    true,
+    [](std::string &) {},
+    [](std::vector<uint8_t> &) {});
+
+  auto json_o = json::parse(R"(
+    {
+      "id": "sub1",
+      "op": "subscribe",
+      "topic": "/topic_that_does_not_exist_yet"
+    }
+  )");
+
+  auto response = handler.process_message(json_o);
+
+  EXPECT_EQ(response["op"], "subscribe_response");
+  EXPECT_EQ(response["result"], false);
+  EXPECT_TRUE(response.contains("error"));
+}
+
+TEST_F(
+  ClientHandlerFixture,
+  subscribe_to_nonexistent_topic_normalizes_rosbridge_style_type)
+{
+  auto server_node = std::make_shared<rclcpp::Node>("server_node");
+  auto node_interface = std::make_shared<NodeInterfaceImpl>(server_node);
+  auto connector = std::make_shared<Connector<>>(node_interface);
+
+  ClientHandler handler( 0, node_interface, connector, true, [](std::string &) {}, [](std::vector<uint8_t> &) {});
+
+  auto json_o = json::parse(R"(
+    {
+      "id": "sub1",
+      "op": "subscribe",
+      "topic": "/topic_that_does_not_exist_yet",
+      "type": "std_msgs/String"
+    }
+  )");
+
+  auto response = handler.process_message(json_o);
+
+  EXPECT_EQ(response["op"], "subscribe_response");
+  EXPECT_EQ(response["result"], true);
+  EXPECT_EQ(response["type"], "std_msgs/msg/String");
+}
+
+TEST_F(
+  ClientHandlerFixture,
+  subscribe_to_existing_topic_fails_when_explicit_type_does_not_match)
+{
+  auto server_node = std::make_shared<rclcpp::Node>("server_node");
+  auto node_interface = std::make_shared<NodeInterfaceImpl>(server_node);
+  auto connector = std::make_shared<Connector<>>(node_interface);
+
+  auto publisher = server_node->create_generic_publisher("/existing_topic", "test_msgs/msg/BasicTypes", rclcpp::QoS(10));
+
+  ClientHandler handler(0, node_interface, connector, true, [](std::string &) {}, [](std::vector<uint8_t> &) {});
+
+  auto json_o = json::parse(R"(
+    {
+      "id": "sub1",
+      "op": "subscribe",
+      "topic": "/existing_topic",
+      "type": "test_msgs/msg/Strings"
+    }
+  )");
+
+  auto response = handler.process_message(json_o);
+
+  EXPECT_EQ(response["op"], "subscribe_response");
+  EXPECT_EQ(response["id"], "sub1");
+  EXPECT_EQ(response["result"], false);
+  EXPECT_TRUE(response.contains("error"));
+
+  EXPECT_NE(publisher, nullptr);
+}
+
 }  // namespace rws
 
 int main(int argc, char ** argv)

--- a/test/connector_test.cpp
+++ b/test/connector_test.cpp
@@ -3,6 +3,12 @@
 
 #include "node_mock.hpp"
 
+#define EXPECT_QOS(qos, expected_reliability, expected_durability) \
+  do { \
+    EXPECT_EQ((qos).reliability(), (expected_reliability)); \
+    EXPECT_EQ((qos).durability(), (expected_durability)); \
+  } while (false)
+
 namespace rws
 {
 
@@ -12,6 +18,18 @@ using testing::MockFunction;
 using testing::Return;
 
 using ConstSharedMessage = std::shared_ptr<const rclcpp::SerializedMessage>;
+
+static rclcpp::TopicEndpointInfo make_publisher_info(const rclcpp::QoS &qos)
+{
+  rcl_topic_endpoint_info_t info{};
+  info.node_name = "test_publisher";
+  info.node_namespace = "/";
+  info.topic_type = "std_msgs/msg/String";
+  info.endpoint_type = RMW_ENDPOINT_PUBLISHER;
+  info.qos_profile = qos.get_rmw_qos_profile();
+
+  return rclcpp::TopicEndpointInfo(info);
+}
 
 class ConnectorFixture : public testing::Test
 {
@@ -44,7 +62,7 @@ TEST_F(ConnectorFixture, subscribe_to_topic_calls_create_generic_subscription_wi
   EXPECT_EQ(params.compression, "none");
 
   EXPECT_CALL(
-    *node, create_generic_subscription("/topic", "std_msgs/msg/String", rclcpp::QoS(10), _, _))
+    *node, create_generic_subscription("/topic", "std_msgs/msg/String", _, _, _))
     .Times(1)
     .WillRepeatedly(Return(nullptr));
 
@@ -81,7 +99,7 @@ TEST_F(
 
   std::function<void(ConstSharedMessage)> topic_callback;
   EXPECT_CALL(
-    *node, create_generic_subscription("/topic", "std_msgs/msg/String", rclcpp::QoS(10), _, _))
+    *node, create_generic_subscription("/topic", "std_msgs/msg/String", _, _, _))
     .Times(1)
     .WillRepeatedly(
       Invoke([&topic_callback](
@@ -129,7 +147,7 @@ TEST_F(
 
   std::function<void(ConstSharedMessage)> topic0_callback;
   EXPECT_CALL(
-    *node, create_generic_subscription("/topic0", "std_msgs/msg/String", rclcpp::QoS(10), _, _))
+    *node, create_generic_subscription("/topic0", "std_msgs/msg/String", _, _, _))
     .Times(1)
     .WillRepeatedly(
       Invoke([&topic0_callback](
@@ -142,7 +160,7 @@ TEST_F(
 
   std::function<void(ConstSharedMessage)> topic1_callback;
   EXPECT_CALL(
-    *node, create_generic_subscription("/topic1", "std_msgs/msg/String", rclcpp::QoS(10), _, _))
+    *node, create_generic_subscription("/topic1", "std_msgs/msg/String", _, _, _))
     .Times(1)
     .WillRepeatedly(
       Invoke([&topic1_callback](
@@ -323,7 +341,7 @@ TEST_F(ConnectorFixture, subscription_callback_throttles_messages)
 
   std::function<void(ConstSharedMessage)> topic_callback;
   EXPECT_CALL(
-    *node, create_generic_subscription("/test_topic", "std_msgs/msg/String", rclcpp::QoS(10), _, _))
+    *node, create_generic_subscription("/test_topic", "std_msgs/msg/String", _, _, _))
     .Times(1)
     .WillRepeatedly(
       Invoke([&topic_callback](
@@ -355,6 +373,200 @@ TEST_F(ConnectorFixture, subscription_callback_throttles_messages)
   EXPECT_EQ(client_msgs.size(), 2);
   EXPECT_EQ(client_msgs[0], messages[0]);
   EXPECT_EQ(client_msgs[1], messages[3]);
+}
+
+TEST_F(
+  ConnectorFixture,
+  subscribe_to_topic_uses_best_effort_when_publisher_is_best_effort)
+{
+  auto node = std::make_shared<NodeMock>();
+  Connector<GenericPublisherMock> connector(node);
+
+  topic_params params("/topic", "std_msgs/msg/String");
+
+  const auto publisher_info =
+    make_publisher_info(rclcpp::QoS(10).best_effort());
+
+  EXPECT_CALL(*node, get_publishers_info_by_topic("/topic", false))
+    .Times(1)
+    .WillOnce(Return(std::vector<rclcpp::TopicEndpointInfo>{publisher_info}));
+
+  EXPECT_CALL(
+    *node,
+    create_generic_subscription("/topic", "std_msgs/msg/String", _, _, _))
+    .Times(1)
+    .WillOnce(Invoke(
+      [](const std::string &,
+         const std::string &,
+         const rclcpp::QoS & qos,
+         std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)>,
+         const rclcpp::SubscriptionOptions &) {
+        EXPECT_QOS(
+          qos,
+          rclcpp::ReliabilityPolicy::BestEffort,
+          rclcpp::DurabilityPolicy::Volatile);
+        return nullptr;
+      }));
+
+  auto handler = [](topic_params, ConstSharedMessage) {};
+  connector.subscribe_to_topic(0, params, handler);
+}
+
+TEST_F(
+  ConnectorFixture,
+  subscribe_to_topic_uses_reliable_when_all_publishers_are_reliable)
+{
+  auto node = std::make_shared<NodeMock>();
+  Connector<GenericPublisherMock> connector(node);
+
+  topic_params params("/topic", "std_msgs/msg/String");
+
+  const auto publisher_info =
+    make_publisher_info(rclcpp::QoS(10).reliable());
+
+  EXPECT_CALL(*node, get_publishers_info_by_topic("/topic", false))
+    .Times(1)
+    .WillOnce(Return(std::vector<rclcpp::TopicEndpointInfo>{publisher_info}));
+
+  EXPECT_CALL(
+    *node,
+    create_generic_subscription("/topic", "std_msgs/msg/String", _, _, _))
+    .Times(1)
+    .WillOnce(Invoke(
+      [](const std::string &,
+         const std::string &,
+         const rclcpp::QoS & qos,
+         std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)>,
+         const rclcpp::SubscriptionOptions &) {
+        EXPECT_QOS(
+          qos,
+          rclcpp::ReliabilityPolicy::Reliable,
+          rclcpp::DurabilityPolicy::Volatile);
+        return nullptr;
+      }));
+
+  auto handler = [](topic_params, ConstSharedMessage) {};
+  connector.subscribe_to_topic(0, params, handler);
+}
+
+TEST_F(
+  ConnectorFixture,
+  subscribe_to_topic_uses_best_effort_when_any_publisher_is_best_effort)
+{
+  auto node = std::make_shared<NodeMock>();
+  Connector<GenericPublisherMock> connector(node);
+
+  topic_params params("/topic", "std_msgs/msg/String");
+
+  const auto reliable_publisher =
+    make_publisher_info(rclcpp::QoS(10).reliable());
+
+  const auto best_effort_publisher =
+    make_publisher_info(rclcpp::QoS(10).best_effort());
+
+  EXPECT_CALL(*node, get_publishers_info_by_topic("/topic", false))
+    .Times(1)
+    .WillOnce(Return(std::vector<rclcpp::TopicEndpointInfo>{
+      reliable_publisher,
+      best_effort_publisher
+    }));
+
+  EXPECT_CALL(
+    *node,
+    create_generic_subscription("/topic", "std_msgs/msg/String", _, _, _))
+    .Times(1)
+    .WillOnce(Invoke(
+      [](const std::string &,
+         const std::string &,
+         const rclcpp::QoS & qos,
+         std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)>,
+         const rclcpp::SubscriptionOptions &) {
+        EXPECT_QOS(
+          qos,
+          rclcpp::ReliabilityPolicy::BestEffort,
+          rclcpp::DurabilityPolicy::Volatile);
+        return nullptr;
+      }));
+
+  auto handler = [](topic_params, ConstSharedMessage) {};
+  connector.subscribe_to_topic(0, params, handler);
+}
+
+TEST_F(
+  ConnectorFixture,
+  subscribe_to_topic_uses_volatile_when_any_publisher_is_volatile)
+{
+  auto node = std::make_shared<NodeMock>();
+  Connector<GenericPublisherMock> connector(node);
+
+  topic_params params("/topic", "std_msgs/msg/String");
+
+  const auto transient_local_publisher =
+    make_publisher_info(rclcpp::QoS(10).transient_local());
+
+  const auto volatile_publisher =
+    make_publisher_info(rclcpp::QoS(10).durability_volatile());
+
+  EXPECT_CALL(*node, get_publishers_info_by_topic("/topic", false))
+    .Times(1)
+    .WillOnce(Return(std::vector<rclcpp::TopicEndpointInfo>{
+      transient_local_publisher,
+      volatile_publisher
+    }));
+
+  EXPECT_CALL(
+    *node,
+    create_generic_subscription("/topic", "std_msgs/msg/String", _, _, _))
+    .Times(1)
+    .WillOnce(Invoke(
+      [](const std::string &,
+         const std::string &,
+         const rclcpp::QoS & qos,
+         std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)>,
+         const rclcpp::SubscriptionOptions &) {
+        EXPECT_QOS(
+          qos,
+          rclcpp::ReliabilityPolicy::Reliable,
+          rclcpp::DurabilityPolicy::Volatile);
+        return nullptr;
+      }));
+
+  auto handler = [](topic_params, ConstSharedMessage) {};
+  connector.subscribe_to_topic(0, params, handler);
+}
+
+TEST_F(
+  ConnectorFixture,
+  subscribe_to_topic_without_publishers_uses_best_effort_volatile_fallback)
+{
+  auto node = std::make_shared<NodeMock>();
+  Connector<GenericPublisherMock> connector(node);
+
+  topic_params params("/topic", "std_msgs/msg/String");
+
+  EXPECT_CALL(*node, get_publishers_info_by_topic("/topic", false))
+    .Times(1)
+    .WillOnce(Return(std::vector<rclcpp::TopicEndpointInfo>{}));
+
+  EXPECT_CALL(
+    *node,
+    create_generic_subscription("/topic", "std_msgs/msg/String", _, _, _))
+    .Times(1)
+    .WillOnce(Invoke(
+      [](const std::string &,
+         const std::string &,
+         const rclcpp::QoS & qos,
+         std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)>,
+         const rclcpp::SubscriptionOptions &) {
+        EXPECT_QOS(
+          qos,
+          rclcpp::ReliabilityPolicy::BestEffort,
+          rclcpp::DurabilityPolicy::Volatile);
+        return nullptr;
+      }));
+
+  auto handler = [](topic_params, ConstSharedMessage) {};
+  connector.subscribe_to_topic(0, params, handler);
 }
 
 }  // namespace rws

--- a/test/mocks/generic_publisher_mock.hpp
+++ b/test/mocks/generic_publisher_mock.hpp
@@ -1,3 +1,6 @@
+#ifndef GENERIC_PUBLISHER_MOCK_H__
+#define GENERIC_PUBLISHER_MOCK_H__
+
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -9,3 +12,5 @@ class GenericPublisherMock
 public:
   MOCK_METHOD(void, publish, (const rclcpp::SerializedMessage message), ());
 };
+
+#endif // GENERIC_PUBLISHER_MOCK_H__

--- a/test/mocks/node_mock.hpp
+++ b/test/mocks/node_mock.hpp
@@ -1,3 +1,5 @@
+#ifndef NODE_MOCK_H__
+#define NODE_MOCK_H__
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -52,3 +54,5 @@ public:
     (const std::string & topic_name, bool no_mangle), (const));
   MOCK_METHOD(std::vector<std::string>, get_node_names, (), (const));
 };
+
+#endif // NODE_MOCK_H__


### PR DESCRIPTION
Hey, it's me again 😄

I've noticed recently that there are some more esoteric topics that get rejected by RWS completely due to incompatible QoS, mainly since it always subscribes with Reliable even to topics that are Best_effort. This change should match all params exactly instead of just durability.

The second thing is that often times I'll have a bunch of subscribers declared in the client ahead of time, and then only later on those publishers get set up and start sending. In this case we don't subscribe at all, and then one has to retry manually from the client. 

So instead we can do what rosbridge does, which is subscribe to the given topic & type with the most compatible QoS, so Best_effort + Volatile. That will not receive old transient local messages since that needs to be set explicitly, but given the alternative I think this is still the far more practical solution.

It seems to work on my end, but I'll be testing a bit more in the coming days to see if I find any edge cases.